### PR TITLE
ENH: Print useful error message if NumPy array is not C-style contiguous

### DIFF
--- a/include/itkPyBuffer.hxx
+++ b/include/itkPyBuffer.hxx
@@ -91,7 +91,16 @@ PyBuffer<TImage>
 
   size_t                      pixelSize     = sizeof(ComponentType);
   size_t                      len           = 1;
-
+  if(PyObject_GetBuffer(arr, &pyBuffer, PyBUF_C_CONTIGUOUS) == -1)
+    {
+    PyErr_SetString( PyExc_RuntimeError,
+    "Array data is not C-style contiguous.\n"
+    "Create a copy (i.e. using '.copy()') of your array first"
+    " to order it C-style." );
+    PyBuffer_Release(&pyBuffer);
+    return NULL;
+    }
+  PyBuffer_Release(&pyBuffer);
   if(PyObject_GetBuffer(arr, &pyBuffer, PyBUF_CONTIG) == -1)
     {
     PyErr_SetString( PyExc_RuntimeError, "Cannot get an instance of NumPy array." );


### PR DESCRIPTION
Instead of simply printing a generic error message if there is a problem
with the input data given to GetImageFromArray, a more specific error
message is printed if the error occurs because the array does not
have C-style contiguity.