### PR TITLE
ENH: Explicit states that 'Get' functions return views

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This is a port from the original WrapITK PyBuffer to an ITKv4 module.
 Differences from the original PyBuffer:
 
 - Support for VectorImage's
-- Option to not swap the axes (only for GetArrayFromImage)
+- Option to not swap the axes (only for GetArrayViewFromImage)
 - Tests
 - Based on the `Python Buffer Protocol <https://docs.python.org/3/c-api/buffer.html>`_ -- does not require NumPy to build.
 
@@ -22,7 +22,7 @@ module.  To enable it, set::
 in ITK's CMake build configuration. In ITK 4.12 and later, this module is
 enabled by default when `ITK_WRAP_PYTHON` is enabled.
 
-To convert an ITK image to a NumPy array::
+To get a view of an ITK image in a NumPy array::
 
   import itk
 
@@ -37,9 +37,9 @@ To convert an ITK image to a NumPy array::
   image.SetRegions(region)
   image.Allocate()
 
-  arr = itk.PyBuffer[ImageType].GetArrayFromImage(image)
+  arr = itk.PyBuffer[ImageType].GetArrayViewFromImage(image)
 
-To convert a NumPy array to an ITK image::
+To get a view of a NumPy array in an ITK image::
 
   import numpy as np
   import itk
@@ -49,9 +49,9 @@ To convert a NumPy array to an ITK image::
   ImageType = itk.Image[PixelType, Dimension]
 
   arr = np.zeros((100, 100, 100), np.float32)
-  image = itk.PyBuffer[ImageType].GetImageFromArray(arr)
+  image = itk.PyBuffer[ImageType].GetImageViewFromArray(arr)
 
-It is also possible to convert VNL matrices and arrays to NumPy arrays and
+It is also possible to get views of VNL matrices and arrays from NumPy arrays and
 back::
 
   import numpy as np
@@ -60,17 +60,17 @@ back::
   ElementType = itk.ctype('float')
   vector = itk.vnl_vector[ElementType]()
   vector.set_size(8)
-  arr = itk.PyVnl[ElementType].GetArrayFromVnlVector(vector)
+  arr = itk.PyVnl[ElementType].GetArrayViewFromVnlVector(vector)
 
   matrix = itk.vnl_matrix[ElementType]()
   matrix.set_size(3, 4)
-  arr = itk.PyVnl[ElementType].GetArrayFromVnlMatrix(matrix)
+  arr = itk.PyVnl[ElementType].GetArrayViewFromVnlMatrix(matrix)
 
   arr = np.zeros((100,), np.float32)
-  vector = itk.PyVnl[ElementType].GetVnlVectorFromArray(arr)
+  vector = itk.PyVnl[ElementType].GetVnlVectorViewFromArray(arr)
 
   arr = np.zeros((100, 100), np.float32)
-  matrix = itk.PyVnl[ElementType].GetVnlMatrixFromArray(arr)
+  matrix = itk.PyVnl[ElementType].GetVnlMatrixViewFromArray(arr)
 
 .. warning::
 
@@ -83,3 +83,20 @@ back::
   image object must be available to use its NumPy array view. Using an array
   view after its source image has been deleted can results in corrupt values
   or a segfault.
+  Modifying the content of a NumPy view of an ITK or VNL object will result
+  in implicitly copy the data from the original ITK or VNL object before
+  modification. The modification will only be visible in the now copy
+  and not in original object. The memory is not shared anymore between
+  ITK or VNL and NumPy. However, modifying the content of an ITK or VNL view
+  of a NumPy object will result in modifying the original NumPy object. No
+  copy is created and the memory is still shared after modification.
+
+It is possible to modify the content of an ITK or VNL object from a NumPy
+view using 'setfield'::
+
+  arr_image=itk.GetArrayFromImage(image)
+  cp_arr = arr_image.copy()
+  # Modify copy of array
+  # hack, hack, hack
+  # Copy modified array into image
+  arr_image.setfield(cp_arr,arr_image.dtype)

--- a/README.rst
+++ b/README.rst
@@ -83,20 +83,3 @@ back::
   image object must be available to use its NumPy array view. Using an array
   view after its source image has been deleted can results in corrupt values
   or a segfault.
-  Modifying the content of a NumPy view of an ITK or VNL object will result
-  in implicitly copy the data from the original ITK or VNL object before
-  modification. The modification will only be visible in the now copy
-  and not in original object. The memory is not shared anymore between
-  ITK or VNL and NumPy. However, modifying the content of an ITK or VNL view
-  of a NumPy object will result in modifying the original NumPy object. No
-  copy is created and the memory is still shared after modification.
-
-It is possible to modify the content of an ITK or VNL object from a NumPy
-view using 'setfield'::
-
-  arr_image=itk.GetArrayFromImage(image)
-  cp_arr = arr_image.copy()
-  # Modify copy of array
-  # hack, hack, hack
-  # Copy modified array into image
-  arr_image.setfield(cp_arr,arr_image.dtype)

--- a/include/itkPyBuffer.h
+++ b/include/itkPyBuffer.h
@@ -37,10 +37,10 @@ namespace itk
 
 /** \class PyBuffer
  *
- *  \brief Helper class for converting C buffers into python arrays.
+ *  \brief Helper class to get ITK image views into python arrays and back.
  *
  *  This class will receive a C buffer and create the equivalent python
- *  array. This permits passing image buffers into python arrays from
+ *  array view. This permits passing image buffers into python arrays from
  *  the NumPy python package.
  *
  *  \ingroup BridgeNumPy
@@ -71,12 +71,12 @@ public:
   /**
    * Get an Array with the content of the image buffer
    */
-  static PyObject * _GetArrayFromImage( ImageType * image);
+  static PyObject * _GetArrayViewFromImage( ImageType * image);
 
   /**
    * Get an ITK image from a Python array
    */
-  static const OutputImagePointer _GetImageFromArray( PyObject *arr, PyObject *shape, PyObject *numOfComponent);
+  static const OutputImagePointer _GetImageViewFromArray( PyObject *arr, PyObject *shape, PyObject *numOfComponent);
 
 protected:
 

--- a/include/itkPyBuffer.hxx
+++ b/include/itkPyBuffer.hxx
@@ -26,7 +26,7 @@ namespace itk
 template<class TImage>
 PyObject *
 PyBuffer<TImage>
-::_GetArrayFromImage( ImageType * image)
+::_GetArrayViewFromImage( ImageType * image)
 {
   PyObject *                  memoryView    = NULL;
   Py_buffer                   pyBuffer;
@@ -70,7 +70,7 @@ PyBuffer<TImage>
 template<class TImage>
 const typename PyBuffer<TImage>::OutputImagePointer
 PyBuffer<TImage>
-::_GetImageFromArray( PyObject *arr, PyObject *shape, PyObject *numOfComponent)
+::_GetImageViewFromArray( PyObject *arr, PyObject *shape, PyObject *numOfComponent)
 {
   PyObject *                  shapeseq      = NULL;
   PyObject *                  item          = NULL;

--- a/include/itkPyVnl.h
+++ b/include/itkPyVnl.h
@@ -34,10 +34,10 @@ namespace itk
 
 /** \class PyVnl
  *
- *  \brief Helper class for converting VNL data buffers into python arrays.
+ *  \brief Helper class get views of VNL data buffers in python arrays and back.
  *
  *  This class will receive a VNL data structure and create the equivalent python
- *  array. This permits passing VNL data structures into python arrays from
+ *  array view. This permits passing VNL data structures into python arrays from
  *  the NumPy python package.
  *
  *  \ingroup BridgeNumPy
@@ -57,22 +57,22 @@ public:
   /**
    * Get an Array with the content of the vnl vector
    */
-  static PyObject * _GetArrayFromVnlVector( VectorType * vector);
+  static PyObject * _GetArrayViewFromVnlVector( VectorType * vector);
 
   /**
    * Get a vnl vector from a Python array
    */
-  static const VectorType _GetVnlVectorFromArray( PyObject *arr, PyObject *shape);
+  static const VectorType _GetVnlVectorViewFromArray( PyObject *arr, PyObject *shape);
 
   /**
    * Get an Array with the content of the vnl matrix
    */
-  static PyObject * _GetArrayFromVnlMatrix( MatrixType * matrix);
+  static PyObject * _GetArrayViewFromVnlMatrix( MatrixType * matrix);
 
   /**
    * Get a vnl matrix from a Python array
    */
-  static const MatrixType _GetVnlMatrixFromArray( PyObject *arr, PyObject *shape);
+  static const MatrixType _GetVnlMatrixViewFromArray( PyObject *arr, PyObject *shape);
 
 
 protected:

--- a/include/itkPyVnl.hxx
+++ b/include/itkPyVnl.hxx
@@ -27,7 +27,7 @@ namespace itk
 template<class TElement>
 PyObject *
 PyVnl<TElement>
-::_GetArrayFromVnlVector( VectorType * vector)
+::_GetArrayViewFromVnlVector( VectorType * vector)
 {
   PyObject *                  memoryView    = NULL;
   Py_buffer                   pyBuffer;
@@ -60,7 +60,7 @@ PyVnl<TElement>
 template<class TElement>
 const typename PyVnl<TElement>::VectorType
 PyVnl<TElement>
-::_GetVnlVectorFromArray( PyObject *arr, PyObject *shape)
+::_GetVnlVectorViewFromArray( PyObject *arr, PyObject *shape)
 {
   PyObject *                  obj           = NULL;
   PyObject *                  shapeseq      = NULL;
@@ -116,7 +116,7 @@ PyVnl<TElement>
 template<class TElement>
 PyObject *
 PyVnl<TElement>
-::_GetArrayFromVnlMatrix( MatrixType * matrix)
+::_GetArrayViewFromVnlMatrix( MatrixType * matrix)
 {
   PyObject *                  memoryView    = NULL;
   Py_buffer                   pyBuffer;
@@ -149,7 +149,7 @@ PyVnl<TElement>
 template<class TElement>
 const typename PyVnl<TElement>::MatrixType
 PyVnl<TElement>
-::_GetVnlMatrixFromArray( PyObject *arr, PyObject *shape)
+::_GetVnlMatrixViewFromArray( PyObject *arr, PyObject *shape)
 {
   PyObject *                  obj           = NULL;
   PyObject *                  shapeseq      = NULL;

--- a/test/itkPyBufferMemoryLeakTest.py
+++ b/test/itkPyBufferMemoryLeakTest.py
@@ -34,7 +34,7 @@ M = []
 X = range(n)
 for i in range(n):
     inputNumpyVolume += 1
-    inputVolume = converter.GetImageFromArray(inputNumpyVolume)
+    inputVolume = converter.GetImageViewFromArray(inputNumpyVolume)
     M.append(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
 if M[5] - M[4] > 1000:
@@ -46,13 +46,13 @@ M = []
 X = [x + n for x in range(n)]
 for i in range(n):
     inputNumpyVolume = np.ones([100,100,100], dtype=np.float32)
-    inputVolume = converter.GetImageFromArray(inputNumpyVolume)
+    inputVolume = converter.GetImageViewFromArray(inputNumpyVolume)
     M.append(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 if M[5] - M[4] > 1000:
     print('Memory leak!')
     sys.exit(1)
 
-# creating new numpy volume but not calling converter.GetImageFromArray(inputNumpyVolume)
+# creating new numpy volume but not calling converter.GetImageViewFromArray(inputNumpyVolume)
 M = []
 X = [x + 2*n for x in range(n)]
 for i in range(n):

--- a/test/itkPyBufferTest.py
+++ b/test/itkPyBufferTest.py
@@ -58,6 +58,32 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
 
         self.assertEqual(0, diff)
 
+    def test_NumPyBridge_itkScalarImageDeepCopy(self):
+        "Try to convert all pixel types to NumPy array view with a deep copy"
+
+        Dimension             = 3
+        ScalarImageType       = itk.Image[itk.UC, Dimension]
+        RegionType            = itk.ImageRegion[Dimension]
+
+        region                = RegionType()
+        region.SetSize(0, 30);
+        region.SetSize(1, 20);
+        region.SetSize(2, 10);
+
+        scalarImage           = ScalarImageType.New()
+        scalarImage.SetRegions(region);
+        scalarImage.Allocate();
+        scalarImage.FillBuffer(0)
+        
+        # Check that scalarndarr is not a view, but a deep copy
+        scalarndarr           = itk.PyBuffer[ScalarImageType].GetArrayFromImage(scalarImage)
+        scalarImage.SetPixel([0,0,0],1)
+        self.assertNotEqual(scalarImage.GetPixel([0,0,0]), scalarndarr[0,0,0])
+        
+        convertedscalarImage  = itk.PyBuffer[ScalarImageType].GetImageFromArray(scalarndarr)
+        scalarndarr[0,0,0] = 2
+        self.assertNotEqual(convertedscalarImage.GetPixel([0,0,0]), scalarndarr[0,0,0])
+
     def test_NumPyBridge_itkVectorImage(self):
         "Try to convert all pixel types to NumPy array view"
 

--- a/test/itkPyBufferTest.py
+++ b/test/itkPyBufferTest.py
@@ -45,8 +45,8 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         scalarImage.SetRegions(region);
         scalarImage.Allocate();
 
-        scalarndarr           = itk.PyBuffer[ScalarImageType].GetArrayFromImage(scalarImage)
-        convertedscalarImage  = itk.PyBuffer[ScalarImageType].GetImageFromArray(scalarndarr)
+        scalarndarr           = itk.PyBuffer[ScalarImageType].GetArrayViewFromImage(scalarImage)
+        convertedscalarImage  = itk.PyBuffer[ScalarImageType].GetImageViewFromArray(scalarndarr)
 
         ScalarDiffFilterType  = itk.ComparisonImageFilter[ScalarImageType, ScalarImageType]
         ScalarDiffFilter      = ScalarDiffFilterType.New()
@@ -74,9 +74,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         vectorImage.SetRegions(region);
         vectorImage.SetNumberOfComponentsPerPixel(3);
         vectorImage.Allocate();
-        vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayFromImage(vectorImage)
+        vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayViewFromImage(vectorImage)
 
-        convertedvectorImage  = itk.PyBuffer[VectorImageType].GetImageFromArray(vectorndarr, isVector=True)
+        convertedvectorImage  = itk.PyBuffer[VectorImageType].GetImageViewFromArray(vectorndarr, isVector=True)
 
     def test_NumPyBridge_itkRGBImage(self):
         "Try to convert an RGB ITK image to NumPy array view"
@@ -94,9 +94,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         rgbImage              = RGBImageType.New()
         rgbImage.SetRegions(region);
         rgbImage.Allocate();
-        rgbndarr              = itk.PyBuffer[RGBImageType].GetArrayFromImage(rgbImage)
+        rgbndarr              = itk.PyBuffer[RGBImageType].GetArrayViewFromImage(rgbImage)
 
-        convertedRGBImage     = itk.PyBuffer[RGBImageType].GetImageFromArray(rgbndarr, isVector=True)
+        convertedRGBImage     = itk.PyBuffer[RGBImageType].GetImageViewFromArray(rgbndarr, isVector=True)
 
     def test_NumPyBridge_itkRGBAImage(self):
         "Try to convert an RGBA ITK image to NumPy array view"
@@ -114,9 +114,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         rgbaImage             = RGBAImageType.New()
         rgbaImage.SetRegions(region);
         rgbaImage.Allocate();
-        rgbandarr             = itk.PyBuffer[RGBAImageType].GetArrayFromImage(rgbaImage)
+        rgbandarr             = itk.PyBuffer[RGBAImageType].GetArrayViewFromImage(rgbaImage)
 
-        convertedRGBAImage    = itk.PyBuffer[RGBAImageType].GetImageFromArray(rgbandarr, isVector=True)
+        convertedRGBAImage    = itk.PyBuffer[RGBAImageType].GetImageViewFromArray(rgbandarr, isVector=True)
 
     def test_NumPyBridge_itkVectorPixelImage(self):
         "Try to convert an ITK image with vector pixels to NumPy array view"
@@ -134,9 +134,9 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         vectorImage           = VectorImageType.New()
         vectorImage.SetRegions(region);
         vectorImage.Allocate();
-        vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayFromImage(vectorImage)
+        vectorndarr           = itk.PyBuffer[VectorImageType].GetArrayViewFromImage(vectorImage)
 
-        convertedVectorImage  = itk.PyBuffer[VectorImageType].GetImageFromArray(vectorndarr, isVector=True)
+        convertedVectorImage  = itk.PyBuffer[VectorImageType].GetImageViewFromArray(vectorndarr, isVector=True)
 
     def test_NumPyBridge_FortranOrder(self):
         "Try to convert an ITK image to / from a NumPy array with Fortran order"
@@ -149,7 +149,7 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
         arr = np.arange(6, dtype=dtype)
         arrC = np.reshape(arr, (2, 3), order='C')
         assert(arrC.flags.c_contiguous)
-        image = itk.PyBuffer[ImageType].GetImageFromArray(arrC)
+        image = itk.PyBuffer[ImageType].GetImageViewFromArray(arrC)
 
         index = itk.Index[Dimension]()
         index[0] = 0
@@ -164,7 +164,7 @@ class TestNumpyITKMemoryviewInterface(unittest.TestCase):
 
         arrFortran = np.reshape(arr, (3, 2), order='F')
         assert(arrFortran.flags.f_contiguous)
-        image = itk.PyBuffer[ImageType].GetImageFromArray(arrFortran)
+        image = itk.PyBuffer[ImageType].GetImageViewFromArray(arrFortran)
         index[0] = 0
         index[1] = 0
         assert(image.GetPixel(index) == 0)

--- a/test/itkPyVnlTest.py
+++ b/test/itkPyVnlTest.py
@@ -45,6 +45,14 @@ class TestNumpyVnlMemoryviewInterface(unittest.TestCase):
         for ii in range(0,v1.size()):
           diff += abs(v1.get(ii)-v2.get(ii))
         self.assertEqual(0, diff)
+        
+        # test deep copy
+        arr_cp = itk.PyVnl.F.GetArrayFromVnlVector(v1)
+        v1.put(0,0)
+        self.assertNotEqual(v1.get(0),arr_cp[0])
+        v2_cp=itk.PyVnl.F.GetVnlVectorFromArray(arr_cp)
+        arr_cp[0]=1
+        self.assertNotEqual(v2_cp.get(0),arr_cp[0])
 
     def test_NumPyBridge_VnlMatrix(self):
         "Try to convert a vnl matrix into a Numpy array and back."
@@ -66,6 +74,15 @@ class TestNumpyVnlMemoryviewInterface(unittest.TestCase):
           for jj in range(m1.cols()):
             diff += abs(m1.get(ii,jj)-m2.get(ii,jj))
         self.assertEqual(0, diff)
+        
+        # test deep copy
+        arr_cp = itk.PyVnl.F.GetArrayFromVnlMatrix(m1)
+        m1.put(0,0,1)
+        self.assertNotEqual(m1.get(0,0), arr_cp[0,0])
+        m2 = itk.PyVnl.F.GetVnlMatrixViewFromArray(arr_cp)
+        arr_cp[0,0]=2
+        self.assertNotEqual(m2.get(0,0), arr_cp[0,0])
+
 
 
 if __name__ == '__main__':

--- a/test/itkPyVnlTest.py
+++ b/test/itkPyVnlTest.py
@@ -37,8 +37,8 @@ class TestNumpyVnlMemoryviewInterface(unittest.TestCase):
         v1.put(1,2)
         v1.put(2,4)
         v1.put(3,5)
-        arr = itk.PyVnl.F.GetArrayFromVnlVector(v1)
-        v2=itk.PyVnl.F.GetVnlVectorFromArray(arr)
+        arr = itk.PyVnl.F.GetArrayViewFromVnlVector(v1)
+        v2=itk.PyVnl.F.GetVnlVectorViewFromArray(arr)
         self.assertEqual(v1.size(), v2.size())
         # Compute difference between the two vectors
         diff = 0.0
@@ -53,8 +53,8 @@ class TestNumpyVnlMemoryviewInterface(unittest.TestCase):
         m1.fill(0)
         m1.put(1,2,1.3)
         m1.put(1,0,2)
-        arr = itk.PyVnl.F.GetArrayFromVnlMatrix(m1)
-        m2 = itk.PyVnl.F.GetVnlMatrixFromArray(arr)
+        arr = itk.PyVnl.F.GetArrayViewFromVnlMatrix(m1)
+        m2 = itk.PyVnl.F.GetVnlMatrixViewFromArray(arr)
         # Check that matrices have the same numer of elements
         self.assertEqual(m1.size(), m2.size())
         # Check that the matrices axes dimensions have not been flipped or changed

--- a/wrapping/PyBuffer.i.in
+++ b/wrapping/PyBuffer.i.in
@@ -5,13 +5,17 @@
 %extend itkPyBuffer@PyBufferTypes@{
     %pythoncode %{
 
-    def GetArrayFromImage(image, keepAxes=False):
-        """Get a NumPy array from a ITK Image.
+    def GetArrayViewFromImage(image, keepAxes=False):
+        """Get a NumPy array view of a ITK Image.
 
         When *keepAxes* is *False*, the NumPy array will have C-order
         indexing. This is the reverse of how indices are specified in ITK,
         i.e. k,j,i versus i,j,k. However C-order indexing is expected by most
         algorithms in NumPy / SciPy.
+
+        Warning: No copy of the data is performed. Using an array
+        view after its source image has been deleted can results in corrupt values
+        or a segfault.
         """
 
         if not HAVE_NUMPY:
@@ -31,16 +35,16 @@
 
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
-        memview       = itkPyBuffer@PyBufferTypes@._GetArrayFromImage(image)
+        memview       = itkPyBuffer@PyBufferTypes@._GetArrayViewFromImage(image)
         itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
         itkndarrview.SetConvertedFlag(converted = True)
 
         return itkndarrview
 
-    GetArrayFromImage = staticmethod(GetArrayFromImage)
+    GetArrayViewFromImage = staticmethod(GetArrayViewFromImage)
 
-    def GetImageFromArray(ndarr, isVector=False):
-        """Get an ITK Image from a NumPy array.
+    def GetImageViewFromArray(ndarr, isVector=False):
+        """Get an ITK Image view of a NumPy array.
 
         If isVector is True, then a 3D array will be treated as a 2D vector image,
         otherwise it will be treated as a 3D image.
@@ -54,6 +58,10 @@
         inverts the indexing scheme, the Image representation will be the
         same for an array and its transpose. If flipping is desired, see
         *numpy.reshape*.
+
+        Warning: No copy of the data is performed. Using an image
+        view after its source array has been deleted can results in corrupt values
+        or a segfault.
         """
 
         if not HAVE_NUMPY:
@@ -63,13 +71,13 @@
             "Only arrays of 2, 3 or 4 dimensions are supported."
 
         if ( ndarr.ndim == 3 and isVector ) or (ndarr.ndim == 4):
-            imgview = itkPyBuffer@PyBufferTypes@._GetImageFromArray( ndarr, ndarr.shape[-2::-1], ndarr.shape[-1] )
+            imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray( ndarr, ndarr.shape[-2::-1], ndarr.shape[-1] )
         elif ndarr.ndim in ( 2, 3 ):
-            imgview = itkPyBuffer@PyBufferTypes@._GetImageFromArray( ndarr, ndarr.shape[::-1], 1)
+            imgview = itkPyBuffer@PyBufferTypes@._GetImageViewFromArray( ndarr, ndarr.shape[::-1], 1)
 
         return imgview
 
-    GetImageFromArray = staticmethod(GetImageFromArray)
+    GetImageViewFromArray = staticmethod(GetImageViewFromArray)
 
   %}
 };

--- a/wrapping/PyBuffer.i.in
+++ b/wrapping/PyBuffer.i.in
@@ -43,6 +43,19 @@
 
     GetArrayViewFromImage = staticmethod(GetArrayViewFromImage)
 
+    def GetArrayFromImage(image):
+        """Get a NumPy ndarray from an ITK Image.
+
+        This is a deep copy of the image buffer and is completely safe and without potential side effects.
+        """
+
+        arrayView = GetArrayViewFromImage(image)
+
+        # perform deep copy of the image buffer
+        return numpy.array(arrayView, copy=True)
+
+    GetArrayFromImage = staticmethod(GetArrayFromImage)
+
     def GetImageViewFromArray(ndarr, isVector=False):
         """Get an ITK Image view of a NumPy array.
 
@@ -78,6 +91,38 @@
         return imgview
 
     GetImageViewFromArray = staticmethod(GetImageViewFromArray)
+
+    def GetImageFromArray(ndarr, isVector=False):
+        """Get an ITK Image of a NumPy array.
+
+        This is a deep copy of the NumPy array buffer and is copletely safe without potential
+        side effects.
+
+        If isVector is True, then a 3D array will be treated as a 2D vector image,
+        otherwise it will be treated as a 3D image.
+
+        If the array uses Fortran-order indexing, i.e. i,j,k, the Image Size
+        will have the same dimensions as the array shape. If the array uses
+        C-order indexing, i.e. k,j,i, the image Size will have the dimensions
+        reversed from the array shape.
+
+        Therefore, since the *numpy.transpose* operator on a 2D array simply
+        inverts the indexing scheme, the Image representation will be the
+        same for an array and its transpose. If flipping is desired, see
+        *numpy.reshape*.
+        """
+
+        # perform deep copy of the array buffer
+        array_copy = numpy.array(ndarr)
+
+        image = GetImageViewFromArray(array_copy, isVector)
+
+        # attaches the copy of the array to the image to avoid releasing memory
+        # when leaving current scope.
+        image.ndarr = array_copy
+        return image
+
+    GetImageFromArray = staticmethod(GetImageFromArray)
 
   %}
 };

--- a/wrapping/PyBuffer.i.in
+++ b/wrapping/PyBuffer.i.in
@@ -118,7 +118,7 @@
 
         # attaches the copy of the array to the image to avoid releasing memory
         # when leaving current scope.
-        image.ndarr = array_copy
+        image._ndarr = array_copy
         return image
 
     GetImageFromArray = staticmethod(GetImageFromArray)

--- a/wrapping/PyBuffer.i.in
+++ b/wrapping/PyBuffer.i.in
@@ -36,10 +36,9 @@
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
         memview       = itkPyBuffer@PyBufferTypes@._GetArrayViewFromImage(image)
-        itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
-        itkndarrview.SetConvertedFlag(converted = True)
+        ndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(numpy.ndarray)
 
-        return itkndarrview
+        return ndarrview
 
     GetArrayViewFromImage = staticmethod(GetArrayViewFromImage)
 
@@ -49,7 +48,7 @@
         This is a deep copy of the image buffer and is completely safe and without potential side effects.
         """
 
-        arrayView = GetArrayViewFromImage(image)
+        arrayView = itkPyBuffer@PyBufferTypes@.GetArrayViewFromImage(image)
 
         # perform deep copy of the image buffer
         return numpy.array(arrayView, copy=True)
@@ -95,7 +94,7 @@
     def GetImageFromArray(ndarr, isVector=False):
         """Get an ITK Image of a NumPy array.
 
-        This is a deep copy of the NumPy array buffer and is copletely safe without potential
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
         side effects.
 
         If isVector is True, then a 3D array will be treated as a 2D vector image,
@@ -115,7 +114,7 @@
         # perform deep copy of the array buffer
         array_copy = numpy.array(ndarr)
 
-        image = GetImageViewFromArray(array_copy, isVector)
+        image = itkPyBuffer@PyBufferTypes@.GetImageViewFromArray(array_copy, isVector)
 
         # attaches the copy of the array to the image to avoid releasing memory
         # when leaving current scope.

--- a/wrapping/PyBuffer.i.init
+++ b/wrapping/PyBuffer.i.init
@@ -27,28 +27,4 @@ def _get_numpy_pixelid(itk_Image_type):
         return _np_itk[itk_Image_type]
     except KeyError as e:
         raise e
-
-
-class itkndarray(numpy.ndarray):
-    """ A customized NumPy.ndarray for ITK Image."""
-
-    bConverted = False
-
-    def SetConvertedFlag(self, converted = True):
-        self.bConverted = converted
-
-    def __setitem__(self, item, to):
-        if self.bConverted == True:
-            temp            = numpy.array(self, copy = True)
-            self.data       = temp.data
-            self.bConverted = False
-        super(itkndarray, self).__setitem__(item, to)
-
-    def itemset(self, *args):
-        if self.bConverted == True:
-            temp            = numpy.array(self, copy = True)
-            self.data       = temp.data
-            self.bConverted = False
-        super(itkndarray, self).itemset(*args)
-
 %}

--- a/wrapping/PyVnlVectorBuffer.i.in
+++ b/wrapping/PyVnlVectorBuffer.i.in
@@ -5,8 +5,13 @@
 %extend itkPyVnl@PyVnlTypes@{
     %pythoncode %{
 
-    def GetArrayFromVnlVector(vnl_vector):
-        """  Get a NumPy array from a Vnl vector.  """
+    def GetArrayViewFromVnlVector(vnl_vector):
+        """  Get a NumPy array view of a Vnl vector.
+
+        Warning: No copy of the data is performed. Using an array
+        view after its source vector has been deleted can results in corrupt values
+        or a segfault.
+        """
 
         if not HAVE_NUMPY:
             raise ImportError('Numpy not available.')
@@ -16,16 +21,21 @@
 
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
-        memview       = itkPyVnl@PyVnlTypes@._GetArrayFromVnlVector(vnl_vector)
+        memview       = itkPyVnl@PyVnlTypes@._GetArrayViewFromVnlVector(vnl_vector)
         itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
         itkndarrview.SetConvertedFlag(converted = True)
 
         return itkndarrview
 
-    GetArrayFromVnlVector = staticmethod(GetArrayFromVnlVector)
+    GetArrayViewFromVnlVector = staticmethod(GetArrayViewFromVnlVector)
 
-    def GetVnlVectorFromArray(ndarr):
-        """ Get a Vnl vector from a NumPy array. """
+    def GetVnlVectorViewFromArray(ndarr):
+        """ Get a Vnl vector view of a NumPy array.
+
+        Warning: No copy of the data is performed. Using a VNL vector
+        view after its source array has been deleted can results in corrupt values
+        or a segfault.
+        """
 
         if not HAVE_NUMPY:
             raise ImportError('Numpy not available.')
@@ -33,14 +43,19 @@
         assert ndarr.ndim == 1 , \
             "Only arrays of 1 dimension are supported."
 
-        vecview = itkPyVnl@PyVnlTypes@._GetVnlVectorFromArray( ndarr, ndarr.shape)
+        vecview = itkPyVnl@PyVnlTypes@._GetVnlVectorViewFromArray( ndarr, ndarr.shape)
 
         return vecview
 
-    GetVnlVectorFromArray = staticmethod(GetVnlVectorFromArray)
+    GetVnlVectorViewFromArray = staticmethod(GetVnlVectorViewFromArray)
 
-    def GetArrayFromVnlMatrix(vnl_matrix):
-        """  Get a NumPy array from a VNL matrix.  """
+    def GetArrayViewFromVnlMatrix(vnl_matrix):
+        """  Get a NumPy array view of a VNL matrix.
+
+        Warning: No copy of the data is performed. Using an array
+        view after its source matrix has been deleted can results in corrupt values
+        or a segfault.
+        """
 
         if not HAVE_NUMPY:
             raise ImportError('Numpy not available.')
@@ -52,16 +67,20 @@
 
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
-        memview       = itkPyVnl@PyVnlTypes@._GetArrayFromVnlMatrix(vnl_matrix)
+        memview       = itkPyVnl@PyVnlTypes@._GetArrayViewFromVnlMatrix(vnl_matrix)
         itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
         itkndarrview.SetConvertedFlag(converted = True)
 
         return itkndarrview
 
-    GetArrayFromVnlMatrix = staticmethod(GetArrayFromVnlMatrix)
+    GetArrayViewFromVnlMatrix = staticmethod(GetArrayViewFromVnlMatrix)
 
-    def GetVnlMatrixFromArray(ndarr):
-        """ Get a VNL Matrix from a NumPy array.
+    def GetVnlMatrixViewFromArray(ndarr):
+        """ Get a VNL Matrix view of a NumPy array.
+
+        Warning: No copy of the data is performed. Using a VNL matrix
+        view after its source array has been deleted can results in corrupt values
+        or a segfault.
         """
         
         if not HAVE_NUMPY:
@@ -70,11 +89,11 @@
         assert ndarr.ndim == 2 , \
             "Only arrays of 2 dimensions are supported."
 
-        matview = itkPyVnl@PyVnlTypes@._GetVnlMatrixFromArray( ndarr, ndarr.shape)
+        matview = itkPyVnl@PyVnlTypes@._GetVnlMatrixViewFromArray( ndarr, ndarr.shape)
 
         return matview
 
-    GetVnlMatrixFromArray = staticmethod(GetVnlMatrixFromArray)
+    GetVnlMatrixViewFromArray = staticmethod(GetVnlMatrixViewFromArray)
 
   %}
 };

--- a/wrapping/PyVnlVectorBuffer.i.in
+++ b/wrapping/PyVnlVectorBuffer.i.in
@@ -6,7 +6,7 @@
     %pythoncode %{
 
     def GetArrayViewFromVnlVector(vnl_vector):
-        """  Get a NumPy array view of a Vnl vector.
+        """  Get a NumPy array view of a VNL vector.
 
         Warning: No copy of the data is performed. Using an array
         view after its source vector has been deleted can results in corrupt values
@@ -22,12 +22,24 @@
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
         memview       = itkPyVnl@PyVnlTypes@._GetArrayViewFromVnlVector(vnl_vector)
-        itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
-        itkndarrview.SetConvertedFlag(converted = True)
+        ndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(numpy.ndarray)
 
-        return itkndarrview
+        return ndarrview
 
     GetArrayViewFromVnlVector = staticmethod(GetArrayViewFromVnlVector)
+
+    def GetArrayFromVnlVector(vnl_vector):
+        """Get a NumPy ndarray from VNL Vector.
+
+        This is a deep copy of the VNL vector and is completely safe and without potential side effects.
+        """
+
+        arrayView = itkPyVnl@PyVnlTypes@.GetArrayViewFromVnlVector(vnl_vector)
+
+        # perform deep copy of the buffer
+        return numpy.array(arrayView, copy=True)
+
+    GetArrayFromVnlVector = staticmethod(GetArrayFromVnlVector)
 
     def GetVnlVectorViewFromArray(ndarr):
         """ Get a Vnl vector view of a NumPy array.
@@ -49,6 +61,25 @@
 
     GetVnlVectorViewFromArray = staticmethod(GetVnlVectorViewFromArray)
 
+    def GetVnlVectorFromArray(ndarr):
+        """Get a VNL vector from a NumPy array.
+
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
+        side effects.
+        """
+
+        # perform deep copy of the array buffer
+        array_copy = numpy.array(ndarr)
+
+        vnl_vector = itkPyVnl@PyVnlTypes@.GetVnlVectorViewFromArray(array_copy)
+
+        # attaches the copy of the array to the vector to avoid releasing memory
+        # when leaving current scope.
+        vnl_vector.ndarr = array_copy
+        return vnl_vector
+
+    GetVnlVectorFromArray = staticmethod(GetVnlVectorFromArray)
+
     def GetArrayViewFromVnlMatrix(vnl_matrix):
         """  Get a NumPy array view of a VNL matrix.
 
@@ -68,12 +99,25 @@
         pixelType     = "@PixelType@"
         numpydatatype = _get_numpy_pixelid(pixelType)
         memview       = itkPyVnl@PyVnlTypes@._GetArrayViewFromVnlMatrix(vnl_matrix)
-        itkndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(itkndarray)
-        itkndarrview.SetConvertedFlag(converted = True)
+        ndarrview  = numpy.asarray(memview).view(dtype = numpydatatype).reshape(shape).view(numpy.ndarray)
 
-        return itkndarrview
+        return ndarrview
 
     GetArrayViewFromVnlMatrix = staticmethod(GetArrayViewFromVnlMatrix)
+    
+    def GetArrayFromVnlMatrix(vnl_matrix):
+        """Get a NumPy ndarray from VNL matrix.
+
+        This is a deep copy of the VNL matrix and is completely safe and without potential side effects.
+        """
+
+        arrayView = itkPyVnl@PyVnlTypes@.GetArrayViewFromVnlMatrix(vnl_matrix)
+
+        # perform deep copy of the buffer
+        return numpy.array(arrayView, copy=True)
+
+    GetArrayFromVnlMatrix = staticmethod(GetArrayFromVnlMatrix)
+    
 
     def GetVnlMatrixViewFromArray(ndarr):
         """ Get a VNL Matrix view of a NumPy array.
@@ -94,6 +138,25 @@
         return matview
 
     GetVnlMatrixViewFromArray = staticmethod(GetVnlMatrixViewFromArray)
+
+    def GetVnlMatrixFromArray(ndarr):
+        """Get a VNL Matrix from a NumPy array.
+
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
+        side effects.
+        """
+
+        # perform deep copy of the array buffer
+        array_copy = numpy.array(ndarr)
+
+        vnl_matrix = itkPyVnl@PyVnlTypes@.GetVnlMatrixViewFromArray(array_copy)
+
+        # attaches the copy of the array to the matrix to avoid releasing memory
+        # when leaving current scope.
+        vnl_matrix.ndarr = array_copy
+        return vnl_matrix
+
+    GetVnlMatrixFromArray = staticmethod(GetVnlMatrixFromArray)
 
   %}
 };

--- a/wrapping/PyVnlVectorBuffer.i.in
+++ b/wrapping/PyVnlVectorBuffer.i.in
@@ -75,7 +75,7 @@
 
         # attaches the copy of the array to the vector to avoid releasing memory
         # when leaving current scope.
-        vnl_vector.ndarr = array_copy
+        vnl_vector._ndarr = array_copy
         return vnl_vector
 
     GetVnlVectorFromArray = staticmethod(GetVnlVectorFromArray)
@@ -153,7 +153,7 @@
 
         # attaches the copy of the array to the matrix to avoid releasing memory
         # when leaving current scope.
-        vnl_matrix.ndarr = array_copy
+        vnl_matrix._ndarr = array_copy
         return vnl_matrix
 
     GetVnlMatrixFromArray = staticmethod(GetVnlMatrixFromArray)


### PR DESCRIPTION
Function names to convert NumPy arrays to ITK or VNL objects were not explicitly
stating that they were returning views on the source object and therefore that:
- The memory was shared among objects.
- The source object was still managing the memory

Functions have been renamed to include the word 'View' to avoid confusion.