### PR TITLE
BUG: CMake configuration should not find Python libraries packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 2.8.9)
 project(BridgeNumPy)
-if(NOT ITK_SOURCE_DIR)
-  include(itk-module-init.cmake)
-endif()
 
 set(BridgeNumPy_SYSTEM_INCLUDE_DIRS "${PYTHON_INCLUDE_DIR}")
 

--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -1,3 +1,0 @@
-list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/CMake")
-
-find_package(PythonLibs REQUIRED)


### PR DESCRIPTION
find_package(PythonLibs REQUIRED) was performed but might end up
configuring BridgeNumPy with different Python libraries than what
was used to configure ITK build directory.