### PR TITLE
BUG: Remove VNL views

### DIFF
--- a/include/itkPyVnl.h
+++ b/include/itkPyVnl.h
@@ -36,9 +36,10 @@ namespace itk
  *
  *  \brief Helper class get views of VNL data buffers in python arrays and back.
  *
- *  This class will receive a VNL data structure and create the equivalent python
- *  array view. This permits passing VNL data structures into python arrays from
- *  the NumPy python package.
+ *  This class will either receive a VNL data structure and create the equivalent
+ *  Python array view or will receive a Python array and create a copy of it in a
+ *  VNL data structure. This permits passing VNL data structures into python arrays
+ *  from the NumPy python package.
  *
  *  \ingroup BridgeNumPy
  */
@@ -62,7 +63,7 @@ public:
   /**
    * Get a vnl vector from a Python array
    */
-  static const VectorType _GetVnlVectorViewFromArray( PyObject *arr, PyObject *shape);
+  static const VectorType _GetVnlVectorFromArray( PyObject *arr, PyObject *shape);
 
   /**
    * Get an Array with the content of the vnl matrix
@@ -72,7 +73,7 @@ public:
   /**
    * Get a vnl matrix from a Python array
    */
-  static const MatrixType _GetVnlMatrixViewFromArray( PyObject *arr, PyObject *shape);
+  static const MatrixType _GetVnlMatrixFromArray( PyObject *arr, PyObject *shape);
 
 
 protected:

--- a/include/itkPyVnl.hxx
+++ b/include/itkPyVnl.hxx
@@ -60,7 +60,7 @@ PyVnl<TElement>
 template<class TElement>
 const typename PyVnl<TElement>::VectorType
 PyVnl<TElement>
-::_GetVnlVectorViewFromArray( PyObject *arr, PyObject *shape)
+::_GetVnlVectorFromArray( PyObject *arr, PyObject *shape)
 {
   PyObject *                  obj           = NULL;
   PyObject *                  shapeseq      = NULL;
@@ -149,7 +149,7 @@ PyVnl<TElement>
 template<class TElement>
 const typename PyVnl<TElement>::MatrixType
 PyVnl<TElement>
-::_GetVnlMatrixViewFromArray( PyObject *arr, PyObject *shape)
+::_GetVnlMatrixFromArray( PyObject *arr, PyObject *shape)
 {
   PyObject *                  obj           = NULL;
   PyObject *                  shapeseq      = NULL;

--- a/test/itkPyVnlTest.py
+++ b/test/itkPyVnlTest.py
@@ -33,55 +33,76 @@ class TestNumpyVnlMemoryviewInterface(unittest.TestCase):
         "Try to convert a vnl vector into a Numpy array and back."
         v1 = itk.vnl_vector[itk.F]()
         v1.set_size(4)
-        v1.put(0,1.3)
-        v1.put(1,2)
-        v1.put(2,4)
-        v1.put(3,5)
+        v1.put(0, 1.3)
+        v1.put(1, 2)
+        v1.put(2, 4)
+        v1.put(3, 5)
         arr = itk.PyVnl.F.GetArrayViewFromVnlVector(v1)
-        v2=itk.PyVnl.F.GetVnlVectorViewFromArray(arr)
+        v2 = itk.PyVnl.F.GetVnlVectorFromArray(arr)
+        self.assertEqual(v1.size(), arr.shape[0])
         self.assertEqual(v1.size(), v2.size())
+        # Compute difference between the original vector and numpy array view
+        diff = 0.0
+        for ii in range(0, v1.size()):
+          diff += abs(v1.get(ii) - arr[ii])
+        self.assertEqual(0, diff)
         # Compute difference between the two vectors
         diff = 0.0
-        for ii in range(0,v1.size()):
-          diff += abs(v1.get(ii)-v2.get(ii))
+        for ii in range(0, v1.size()):
+          diff += abs(v1.get(ii) - v2.get(ii))
         self.assertEqual(0, diff)
-        
-        # test deep copy
+        # Test view
+        v1.put(0, 1)
+        self.assertEqual(v1.get(0), arr[0])
+        # Test deep copy
         arr_cp = itk.PyVnl.F.GetArrayFromVnlVector(v1)
-        v1.put(0,0)
-        self.assertNotEqual(v1.get(0),arr_cp[0])
+        self.assertEqual(v1.get(0), arr_cp[0])
+        v1.put(0, 0)
+        self.assertNotEqual(v1.get(0), arr_cp[0])
         v2_cp=itk.PyVnl.F.GetVnlVectorFromArray(arr_cp)
-        arr_cp[0]=1
-        self.assertNotEqual(v2_cp.get(0),arr_cp[0])
+        arr_cp[0] = 2
+        self.assertNotEqual(v2_cp.get(0), arr_cp[0])
 
     def test_NumPyBridge_VnlMatrix(self):
         "Try to convert a vnl matrix into a Numpy array and back."
         m1 = itk.vnl_matrix[itk.F]()
-        m1.set_size(2,3)
+        m1.set_size(2, 3)
         m1.fill(0)
-        m1.put(1,2,1.3)
-        m1.put(1,0,2)
+        m1.put(1, 2, 1.3)
+        m1.put(1, 0, 2)
         arr = itk.PyVnl.F.GetArrayViewFromVnlMatrix(m1)
-        m2 = itk.PyVnl.F.GetVnlMatrixViewFromArray(arr)
+        m2 = itk.PyVnl.F.GetVnlMatrixFromArray(arr)
         # Check that matrices have the same numer of elements
         self.assertEqual(m1.size(), m2.size())
+        self.assertEqual(m1.size(), arr.size)
         # Check that the matrices axes dimensions have not been flipped or changed
+        self.assertEqual(m1.rows(), arr.shape[0])
+        self.assertEqual(m1.columns(), arr.shape[1])
         self.assertEqual(m1.rows(), m2.rows())
         self.assertEqual(m1.columns(), m2.columns())
+        # Compute any difference between the original matrix and the numpy array view
+        diff = 0.0
+        for ii in range(m1.rows()):
+          for jj in range(m1.cols()):
+            diff += abs(m1.get(ii, jj) - arr[ii, jj])
+        self.assertEqual(0, diff)
         # Compute any difference between the two matrices
         diff = 0.0
         for ii in range(m1.rows()):
           for jj in range(m1.cols()):
-            diff += abs(m1.get(ii,jj)-m2.get(ii,jj))
+            diff += abs(m1.get(ii, jj) - m2.get(ii, jj))
         self.assertEqual(0, diff)
-        
-        # test deep copy
+        # Test view
+        m1.put(0, 0, 1)
+        self.assertEqual(m1.get(0, 0), arr[0, 0])
+        # Test deep copy
         arr_cp = itk.PyVnl.F.GetArrayFromVnlMatrix(m1)
-        m1.put(0,0,1)
-        self.assertNotEqual(m1.get(0,0), arr_cp[0,0])
-        m2 = itk.PyVnl.F.GetVnlMatrixViewFromArray(arr_cp)
-        arr_cp[0,0]=2
-        self.assertNotEqual(m2.get(0,0), arr_cp[0,0])
+        self.assertEqual(m1.get(0, 0), arr_cp[0, 0])
+        m1.put(0, 0, 2)
+        self.assertNotEqual(m1.get(0, 0), arr_cp[0, 0])
+        m2 = itk.PyVnl.F.GetVnlMatrixFromArray(arr_cp)
+        arr_cp[0, 0] = 2
+        self.assertNotEqual(m2.get(0, 0), arr_cp[0, 0])
 
 
 

--- a/wrapping/PyVnlVectorBuffer.i.in
+++ b/wrapping/PyVnlVectorBuffer.i.in
@@ -41,12 +41,12 @@
 
     GetArrayFromVnlVector = staticmethod(GetArrayFromVnlVector)
 
-    def GetVnlVectorViewFromArray(ndarr):
-        """ Get a Vnl vector view of a NumPy array.
+    def GetVnlVectorFromArray(ndarr):
+        """Get a VNL vector from a NumPy array.
 
-        Warning: No copy of the data is performed. Using a VNL vector
-        view after its source array has been deleted can results in corrupt values
-        or a segfault.
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
+        side effects.  It is not possible to have a view of a numpy array in a VNL vector since
+        there is no VNL vector constructor that allows sharing data.
         """
 
         if not HAVE_NUMPY:
@@ -55,28 +55,9 @@
         assert ndarr.ndim == 1 , \
             "Only arrays of 1 dimension are supported."
 
-        vecview = itkPyVnl@PyVnlTypes@._GetVnlVectorViewFromArray( ndarr, ndarr.shape)
+        vec = itkPyVnl@PyVnlTypes@._GetVnlVectorFromArray( ndarr, ndarr.shape)
 
-        return vecview
-
-    GetVnlVectorViewFromArray = staticmethod(GetVnlVectorViewFromArray)
-
-    def GetVnlVectorFromArray(ndarr):
-        """Get a VNL vector from a NumPy array.
-
-        This is a deep copy of the NumPy array buffer and is completely safe without potential
-        side effects.
-        """
-
-        # perform deep copy of the array buffer
-        array_copy = numpy.array(ndarr)
-
-        vnl_vector = itkPyVnl@PyVnlTypes@.GetVnlVectorViewFromArray(array_copy)
-
-        # attaches the copy of the array to the vector to avoid releasing memory
-        # when leaving current scope.
-        vnl_vector._ndarr = array_copy
-        return vnl_vector
+        return vec
 
     GetVnlVectorFromArray = staticmethod(GetVnlVectorFromArray)
 
@@ -119,12 +100,12 @@
     GetArrayFromVnlMatrix = staticmethod(GetArrayFromVnlMatrix)
     
 
-    def GetVnlMatrixViewFromArray(ndarr):
-        """ Get a VNL Matrix view of a NumPy array.
+    def GetVnlMatrixFromArray(ndarr):
+        """Get a VNL Matrix from a NumPy array.
 
-        Warning: No copy of the data is performed. Using a VNL matrix
-        view after its source array has been deleted can results in corrupt values
-        or a segfault.
+        This is a deep copy of the NumPy array buffer and is completely safe without potential
+        side effects. It is not possible to have a view of a numpy array in a VNL matrix since there is no
+        VNL matrix constructor that allows sharing data.
         """
         
         if not HAVE_NUMPY:
@@ -133,28 +114,9 @@
         assert ndarr.ndim == 2 , \
             "Only arrays of 2 dimensions are supported."
 
-        matview = itkPyVnl@PyVnlTypes@._GetVnlMatrixViewFromArray( ndarr, ndarr.shape)
+        mat = itkPyVnl@PyVnlTypes@._GetVnlMatrixFromArray( ndarr, ndarr.shape)
 
-        return matview
-
-    GetVnlMatrixViewFromArray = staticmethod(GetVnlMatrixViewFromArray)
-
-    def GetVnlMatrixFromArray(ndarr):
-        """Get a VNL Matrix from a NumPy array.
-
-        This is a deep copy of the NumPy array buffer and is completely safe without potential
-        side effects.
-        """
-
-        # perform deep copy of the array buffer
-        array_copy = numpy.array(ndarr)
-
-        vnl_matrix = itkPyVnl@PyVnlTypes@.GetVnlMatrixViewFromArray(array_copy)
-
-        # attaches the copy of the array to the matrix to avoid releasing memory
-        # when leaving current scope.
-        vnl_matrix._ndarr = array_copy
-        return vnl_matrix
+        return mat
 
     GetVnlMatrixFromArray = staticmethod(GetVnlMatrixFromArray)
 


### PR DESCRIPTION
VNL vectors and matrices only have constructors that copy the input data. It is
therefore not possible to create a view on NumPy arrays with VNL vectors and
matrices. These functions were not working and are therefore removed.
It is still possible to create views on VNL vectors and matrices with NumPy
arrays.